### PR TITLE
document api_key setting; explain env config

### DIFF
--- a/src/util/help.js
+++ b/src/util/help.js
@@ -192,12 +192,13 @@ function addGrafanaConfiguration() {
   help += '\n   wizzy set grafana url GRAFANA_URL';
   help += '\n   wizzy set grafana username GRAFANA_USERNAME';
   help += '\n   wizzy set grafana password GRAFANA_PASSWORD';
+  help += '\n   wizzy set grafana api_key GRAFANA_API_KEY';
   help += '\n   wizzy set grafana headers HEADER_NAME HEADER_VALUE';
   help += '\n   wizzy set grafana authorization false';
   help += '\n   wizzy set grafana debug_api true';
-  help += '\n   wizzy set grafana envs ENV_NAME url GRAFANA_URL';
+  help += '\n   wizzy set grafana envs ENV_NAME GRAFANA_FLAG GRAFANA_FLAG_VALUE';
   help += '\n   wizzy unset grafana username';
-  help += '\n   wizzy unset grafana envs ENV_NAME url';
+  help += '\n   wizzy unset grafana envs ENV_NAME GRAFANA_FLAG';
   help += '\n';
 }
 


### PR DESCRIPTION
prints the api_key setting in the help output

uses a more generic example for env specific configs (just showing url might be confusing, since all properties are supported)