### PR TITLE
Import Dashboard via UID

### DIFF
--- a/src/local/dashboards.js
+++ b/src/local/dashboards.js
@@ -75,7 +75,7 @@ Dashboards.prototype.saveDashboard = function(slug, dashboard, meta, showResult)
   delete dashboard.version;
   localfs.writeFile(getDashboardFile(slug, folder), logger.stringify(dashboard, null, 2));
   if (showResult) {
-    logger.showResult(`${slug} dashboard saved successfully under dashboards directory.`);
+    logger.showResult(`${slug} dashboard saved successfully under dashboards/${folder} directory.`);
   }
 };
 


### PR DESCRIPTION
Changes to import dashboards via uid. Get dashboard by slug is now deprecated https://grafana.com/docs/grafana/latest/http_api/dashboard/#get-dashboard-by-slug