### PR TITLE
fix(command): Fix version command.

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -9,6 +9,7 @@ const Dashlist = require('./local/dashlist.js');
 const Logger = require('./util/logger.js');
 const Help = require('./util/help.js');
 const LocalFS = require('./util/localfs.js');
+const pkg = require('../package.json')
 
 const localfs = new LocalFS();
 const logger = new Logger('Commands');
@@ -44,7 +45,8 @@ Commands.prototype.instructions = function() {
 
   switch (command) {
     case 'version':
-      logger.justShow('0.6.0');
+      const { version } = pkg
+      logger.justShow(version);
       break;
     case 'help':
       help.showHelp();


### PR DESCRIPTION
Hi! Long time listener, first-time caller. 👋

### What does this PR do?
Updates the version string printed by the `wizzy version` command. It was hardcoded to `0.6.0` and not updated when `0.7.0` was released. I've updated the module to instead parse the `version` from `package.json`, to avoid these falling out of sync in the future.